### PR TITLE
Made compatible with IntelliJ Idea version 2020.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ version '1.2.4'
 sourceCompatibility = 1.8
 
 intellij {
-    version '2020.1'
+    version '2020.2'
 }
 
 dependencies {


### PR DESCRIPTION
Changed the intellj version to 2020.2
Maybe you should consider changing to a since-build & until-build version numbering to avoid changing this every time there's a new version.
See: [version numbering system with since-build & until-build](https://jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html) 